### PR TITLE
Missing Lib, gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sounds/
 # distribution
 build/
 dist/
+.env/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyperclip
 sound_lib
 wxpython
 https://github.com/cartertemm/habitica-api/archive/refs/heads/main.zip
+appdirs


### PR DESCRIPTION
Set up venv and installed all packages, got tracebacks for missing appdir lib, so went ahead and added that to requirements.txt. Also added an entry  in.gitignore to ignore python virtual environments.